### PR TITLE
Topic/dcm bias estimator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # received a copy of the GNU Lesser General Public License along with
 # state-observation. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1.4)
 if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()

--- a/include/state-observation/dynamics-estimators/kinetics-observer.hpp
+++ b/include/state-observation/dynamics-estimators/kinetics-observer.hpp
@@ -1,5 +1,5 @@
 /**
- * \file      kinetics-observer-base.hpp
+ * \file      kinetics-observer.hpp
  * \author    Mehdi Benallegue
  * \date      2018
  * \brief     Unified Kinetics estimator
@@ -30,10 +30,8 @@ namespace stateObservation
 {
 
 /**
- * \class  EKFFlexibilityEstimatorBase
- * \brief  This class is the base class of the flexibility estimators that
- *         use an extended Kalman Filter. Several methods require to be overloaded
- *         to derive an implementation from this base class.
+ * \class  KineticsObserver
+ * \brief
  *
  */
 

--- a/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
+++ b/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
@@ -30,7 +30,7 @@ namespace stateObservation
 /// The DCM can be measured using the CoM and its velocity, but the CoM position can be biased.
 /// This estimator uses Kalman Filtering to estimate this bias in one axis.
 
-class LipmDcmBiasEstimator
+class STATE_OBSERVATION_DLLAPI LipmDcmBiasEstimator
 {
 private:
   constexpr static double defaultDt_ = 0.005;

--- a/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
+++ b/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
@@ -62,10 +62,11 @@ public:
   LipmDcmBiasEstimator(double omega_0,
                        double dt = defaultDt_,
                        double biasDriftStd = defaultBiasDriftSecond_,
-                       double zmpMeasureErrorStd = defaultZmpErrorStd_,
-                       double dcmMeasureErrorStd = defaultDcmErrorStd_,
+                       double initZMP = 0,
                        double initDcm = 0,
                        double initBias = 0,
+                       double zmpMeasureErrorStd = defaultZmpErrorStd_,
+                       double dcmMeasureErrorStd = defaultDcmErrorStd_,
                        double initDcmUncertainty = defaultDCMUncertainty,
                        double initBiasUncertainty = defaultBiasUncertainty);
 
@@ -84,6 +85,7 @@ public:
   /// @param initBiasUncertainty the uncertainty in the bias initial value in meters
   LipmDcmBiasEstimator(bool measurementIsWithBias,
                        double measuredDcm,
+                       double measuredZMP,
                        double omega_0,
                        double dt = defaultDt_,
                        double biasDriftStd = defaultBiasDriftSecond_,
@@ -187,6 +189,8 @@ private:
   double dt_;
   double biasDriftStd_;
   double zmpErrorStd_;
+
+  double previousZmp_;
 
   LinearKalmanFilter filter_;
   Matrix2 A_;

--- a/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
+++ b/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
@@ -1,0 +1,208 @@
+
+///\file      lipm-dcm-bias-estimator.hpp
+///\author    Mehdi Benallegue
+///\date      2020
+///\brief     Estimation of a bias betweeen the divergent component of motion
+///           and the corresponding zero moment point for a linearized inverted
+///           pendulum model
+///
+///\detail
+///
+///
+#ifndef LIPMDCMBIASESTIMATOR_HPP
+#define LIPMDCMBIASESTIMATOR_HPP
+
+#include <state-observation/api.h>
+#include <state-observation/observer/linear-kalman-filter.hpp>
+
+namespace stateObservation
+{
+
+/// \class LipmDcmBiasEstimator
+/// \brief Estimation of a bias betweeen the divergent component of motion
+///        and the corresponding zero moment point for a linearized inverted
+///        pendulum model.
+///
+/// \details
+/// A humanoid robot can be modeled as an inverted pendulum. The dynamics can be
+/// linearized to obtain a dynamics with a convergent and a divergent component of motion (DCN).
+/// The dynamics of the DCM depends on the Zero Moment Point.
+/// The DCM can be measured using the CoM and its velocity, but the CoM position can be biased.
+/// This estimator uses Kalman Filtering to estimate this bias in one axis.
+
+class LipmDcmBiasEstimator
+{
+private:
+  constexpr static double defaultDt_ = 0.005;
+
+  /// default expected drift of the bias every second
+  constexpr static double defaultBiasDriftSecond_ = 0.002;
+
+  /// default error in the estimation of the sensors
+  constexpr static double defaultZmpErrorStd_ = 0.005;
+  constexpr static double defaultDcmErrorStd_ = 0.01;
+
+  /// default uncertainty in the initial values of DCM and Bias
+  constexpr static double defaultDCMUncertainty = 0.01;
+  constexpr static double defaultBiasUncertainty = 0.01;
+
+public:
+  /// @brief Construct a new Lipm Dcm Bias Estimator object
+  /// @details Use this if no DCM measurements are available or when a good guess of its unbiased position is available
+  ///
+  /// @param omega_0             the natural frequency of the DCM (rad/s)
+  /// @param dt                  the sampling time in seconds
+  /// @param biasDriftStd        the standard deviation of the drift (m/s)
+  /// @param zmpMeasureErrorStd  the standard deviaiton of the zmp estimation error (m)
+  /// @param dcmMeasureErrorStd  the standard deviation of the dcm estimation error, NOT including the bias (m)
+  /// @param initDCM             the initial value of the DCM
+  /// @param initBias            the initial value of the bias
+  /// @param tinitDcmUncertainty the uncertainty in the DCM initial value in meters
+  /// @param initBiasUncertainty the uncertainty in the bias initial value in meters
+  LipmDcmBiasEstimator(double omega_0,
+                       double dt = defaultDt_,
+                       double biasDriftStd = defaultBiasDriftSecond_,
+                       double zmpMeasureErrorStd = defaultZmpErrorStd_,
+                       double dcmMeasureErrorStd = defaultDcmErrorStd_,
+                       double initDcm = 0,
+                       double initBias = 0,
+                       double initDcmUncertainty = defaultDCMUncertainty,
+                       double initBiasUncertainty = defaultBiasUncertainty);
+
+  /// @brief Construct a new Lipm Dcm Bias Estimator object
+  /// @details Use this when initializing with an available DCM (biased) measurement
+  ///
+  /// @param measurementIsWithBias  sets if yes or no the measurement is with the bias. It is better set to true than
+  /// trying to remove it beforehand
+  /// @param measuredDcm            the the measured position of the DCM
+  /// @param omega_0                the natural frequency of the DCM (rad/s)
+  /// @param dt                     the sampling time in seconds
+  /// @param biasDriftStd           the standard deviation of the drift (m/s)
+  /// @param zmpMeasureErrorStd     the standard deviaiton of the zmp estimation error (m)
+  /// @param scmMeasureErrorStd     the standard deviation of the dcm estimation error, NOT including the bias (m)
+  /// @param initBias               the initial value of the drift
+  /// @param initBiasUncertainty the uncertainty in the bias initial value in meters
+  LipmDcmBiasEstimator(bool measurementIsWithBias,
+                       double measuredDcm,
+                       double omega_0,
+                       double dt = defaultDt_,
+                       double biasDriftStd = defaultBiasDriftSecond_,
+                       double zmpMeasureErrorStd = defaultZmpErrorStd_,
+                       double dcmMeasureErrorStd = defaultDcmErrorStd_,
+                       double initBias = 0,
+                       double initBiasuncertainty = defaultBiasUncertainty);
+
+  ///@brief Destroy the Lipm Dcm Bias Estimator object
+  ~LipmDcmBiasEstimator();
+
+  ///@brief Set the Lipm Natural Frequency
+  ///
+  ///@param omega_0  is the sampling time in seconds
+  void setLipmNaturalFrequency(double omega_0);
+
+  ///@brief Set the Sampling Time
+  ///
+  ///@param dt sampling time
+  void setSamplingTime(double dt);
+
+  ///@brief Set the Bias object from a guess
+  ///
+  ///@param bias guess
+  void setBias(double bias);
+
+  ///@copydoc setBias(double bias)
+  ///
+  ///@param the uncertainty you have in this guess in meters
+  void setBias(double bias, double uncertainty);
+
+  /// @brief Set the Bias Drift Per Second
+  ///
+  /// @param driftPerSecond the standard deviation of the drift (m/s)
+  void setBiasDriftPerSecond(double driftPerSecond);
+
+  /// @brief set the real DCM position from a guess
+  ///
+  /// @param dcm guess
+  void setDCM(double dcm);
+
+  /// @copydoc setDCM(double dcm)
+  ///
+  /// @param dcm
+  /// @param uncertainty the uncertainty in this guess
+  void setDCM(double dcm, double uncertainty);
+
+  /// @brief Set the Zmp Measurement Error Stamdard devbiation
+  ///
+  void setZmpMeasureErrorStd(double);
+
+  /// @brief Set the Dcm Measurement Error Standard
+  ///
+  void setDcmMeasureErrorStd(double);
+
+  /// @brief Set the Inputs of the estimator
+  ///
+  /// @param dcm
+  /// @param zmp
+  void setInputs(double dcm, double zmp);
+
+  /// @brief Runs the estimation. Needs to be called every timestep
+  ///
+  /// @return Vector2
+  inline Vector2 update()
+  {
+    return filter_.getEstimatedState(filter_.getMeasurementTime());
+  }
+
+  /// @brief Get the Unbiased DCM filtered by the estimator
+  ///
+  /// @detailt This is the recommended output to take
+  /// @return double
+  double getUnbiasedDCM() const;
+
+  /// @brief Get the estimated Bias
+  ///
+  /// @return double
+  double getBias() const;
+
+  /// @brief Get the Kalman Filter object
+  /// This can be used to run specific Advanced Kalman filter related funcions
+  /// @return LinearKalmanFilter&
+  inline LinearKalmanFilter & getFilter()
+  {
+    return filter_;
+  }
+
+  /// @copydoc getFilter()
+  /// const version
+  inline const LinearKalmanFilter & getFilter() const
+  {
+    return filter_;
+  }
+
+private:
+  /// @brief set Matrices: A, B, Q
+  void updateMatricesABQ_();
+
+  double omega0_;
+  double dt_;
+  double biasDriftStd_;
+  double zmpErrorStd_;
+
+  LinearKalmanFilter filter_;
+  Matrix2 A_;
+  Vector2 B_;
+  /// this needs to be transposed
+  Vector2 C_;
+  /// measurement noise
+  Matrix1 R_;
+
+  /// process noise
+  Matrix2 Q_;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+} // namespace stateObservation
+
+#endif /// LIPMDCMBIASESTIMATOR_HPP

--- a/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
+++ b/include/state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp
@@ -50,18 +50,18 @@ public:
   /// @brief Construct a new Lipm Dcm Bias Estimator object
   /// @details Use this if no DCM measurements are available or when a good guess of its unbiased position is available
   ///
-  /// @param omega_0             the natural frequency of the DCM (rad/s)
-  /// @param dt                  the sampling time in seconds
-  /// @param biasDriftStd        the standard deviation of the drift (m/s)
-  /// @param zmpMeasureErrorStd  the standard deviaiton of the zmp estimation error (m)
-  /// @param dcmMeasureErrorStd  the standard deviation of the dcm estimation error, NOT including the bias (m)
-  /// @param initDCM             the initial value of the DCM
-  /// @param initBias            the initial value of the bias
-  /// @param tinitDcmUncertainty the uncertainty in the DCM initial value in meters
-  /// @param initBiasUncertainty the uncertainty in the bias initial value in meters
+  /// @param omega_0                the natural frequency of the DCM (rad/s)
+  /// @param dt                     the sampling time in seconds
+  /// @param biasDriftPerSecondStd  the standard deviation of the drift (m/s)
+  /// @param zmpMeasureErrorStd     the standard deviaiton of the zmp estimation error (m)
+  /// @param dcmMeasureErrorStd     the standard deviation of the dcm estimation error, NOT including the bias (m)
+  /// @param initDCM                the initial value of the DCM
+  /// @param initBias               the initial value of the bias
+  /// @param tinitDcmUncertainty    the uncertainty in the DCM initial value in meters
+  /// @param initBiasUncertainty    the uncertainty in the bias initial value in meters
   LipmDcmBiasEstimator(double omega_0,
                        double dt = defaultDt_,
-                       double biasDriftStd = defaultBiasDriftSecond_,
+                       double biasDriftPerSecondStd = defaultBiasDriftSecond_,
                        double initZMP = 0,
                        double initDcm = 0,
                        double initBias = 0,
@@ -78,7 +78,7 @@ public:
   /// @param measuredDcm            the the measured position of the DCM
   /// @param omega_0                the natural frequency of the DCM (rad/s)
   /// @param dt                     the sampling time in seconds
-  /// @param biasDriftStd           the standard deviation of the drift (m/s)
+  /// @param biasDriftPerSecondStd  the standard deviation of the drift (m/s)
   /// @param zmpMeasureErrorStd     the standard deviaiton of the zmp estimation error (m)
   /// @param scmMeasureErrorStd     the standard deviation of the dcm estimation error, NOT including the bias (m)
   /// @param initBias               the initial value of the drift
@@ -88,7 +88,7 @@ public:
                        double measuredZMP,
                        double omega_0,
                        double dt = defaultDt_,
-                       double biasDriftStd = defaultBiasDriftSecond_,
+                       double biasDriftPerSecondStd = defaultBiasDriftSecond_,
                        double zmpMeasureErrorStd = defaultZmpErrorStd_,
                        double dcmMeasureErrorStd = defaultDcmErrorStd_,
                        double initBias = 0,
@@ -202,6 +202,10 @@ private:
 
   /// process noise
   Matrix2 Q_;
+
+  /// @brief Deactivated default constructor
+  ///
+  LipmDcmBiasEstimator() = delete;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/state-observation/observer/kalman-filter-base.hpp
+++ b/include/state-observation/observer/kalman-filter-base.hpp
@@ -151,6 +151,10 @@ public:
   /// Set the covariance matrix of the current time state estimation error
   virtual void setStateCovariance(const Pmatrix & P);
 
+  /// @brief clears the state and the state covariance
+  /// @details they need to be set again using setState() and setStateCovariance() before starting the estimation again
+  virtual void clearStates();
+
   /// Clear the covariace matrix of the current time state estimation
   /// error
   virtual void clearStateCovariance();

--- a/include/state-observation/observer/observer-base.hpp
+++ b/include/state-observation/observer/observer-base.hpp
@@ -80,19 +80,19 @@ public:
   /// Set the value of the state vector at time index k
   virtual void setState(const StateVector & x_k, TimeIndex k) = 0;
 
-  /// Remove all the given past values of the state
+  /// Remove all the given values of the state
   virtual void clearStates() = 0;
 
   /// Set the value of the measurements vector at time index k
   virtual void setMeasurement(const MeasureVector & y_k, TimeIndex k) = 0;
 
-  /// Remove all the given past values of the measurements
+  /// Remove all the given values of the measurements
   virtual void clearMeasurements() = 0;
 
   /// Set the value of the input vector at time index k
   virtual void setInput(const InputVector & x_k, TimeIndex k) = 0;
 
-  /// Remove all the given past values of the inputs
+  /// Remove all the given values of the inputs
   virtual void clearInputs() = 0;
 
   /// Run the observer loop and gets the state estimation of the state at

--- a/include/state-observation/observer/observer-base.hpp
+++ b/include/state-observation/observer/observer-base.hpp
@@ -95,6 +95,9 @@ public:
   /// Remove all the given values of the inputs
   virtual void clearInputs() = 0;
 
+  /// @brief  Remove all the given values of the inputs and measurements
+  virtual void clearInputsAndMeasurements();
+
   /// Run the observer loop and gets the state estimation of the state at
   /// instant k
   virtual StateVector getEstimatedState(TimeIndex k) = 0;

--- a/include/state-observation/observer/zero-delay-observer.hpp
+++ b/include/state-observation/observer/zero-delay-observer.hpp
@@ -71,7 +71,8 @@ public:
   /// state/estimate with a new one
   virtual void setCurrentState(const ObserverBase::StateVector & x_k);
 
-  /// Remove all the given past values of the state
+  /// @brief  Removes the state estimation
+  /// @details inherited from ObserverBase
   virtual void clearStates();
 
   /// Set the value of the measurements vector at time index k. The
@@ -83,7 +84,7 @@ public:
   /// @param y_k Value of the next measurement
   virtual void pushMeasurement(const ObserverBase::MeasureVector & y_k);
 
-  /// Remove all the given past values of the measurements
+  /// Remove all the given values of the measurements
   virtual void clearMeasurements();
 
   /// Set the value of the input vector at time index k. The
@@ -96,7 +97,7 @@ public:
   /// @param u_k Value of the next input
   virtual void pushInput(const ObserverBase::InputVector & u_k);
 
-  /// Remove all the given past values of the inputs
+  /// Remove all the given values of the inputs
   /// If there is no input, this instruction has no effect
   virtual void clearInputs();
 

--- a/include/state-observation/observer/zero-delay-observer.hpp
+++ b/include/state-observation/observer/zero-delay-observer.hpp
@@ -60,12 +60,28 @@ public:
   /// highest index is called the current time k_0
   virtual void setState(const ObserverBase::StateVector & x_k, TimeIndex k);
 
+  /// @brief Modify the value of the state vector at the current time.
+  ///
+  /// @param x_k The new state value
+  ///
+  /// This method should NOT be used for first initialization
+  /// Use setState() instead.
+  ///
+  /// Calling this function will not affect the measurements nor the input vectors. It will only replace the current
+  /// state/estimate with a new one
+  virtual void setCurrentState(const ObserverBase::StateVector & x_k);
+
   /// Remove all the given past values of the state
   virtual void clearStates();
 
   /// Set the value of the measurements vector at time index k. The
   /// measurements have to be inserted in chronological order without gaps.
   virtual void setMeasurement(const ObserverBase::MeasureVector & y_k, TimeIndex k);
+
+  /// @brief Sets the measurement value at the next time index
+  ///
+  /// @param y_k Value of the next measurement
+  virtual void pushMeasurement(const ObserverBase::MeasureVector & y_k);
 
   /// Remove all the given past values of the measurements
   virtual void clearMeasurements();
@@ -74,6 +90,11 @@ public:
   /// inputs have to be inserted in chronological order without gaps.
   /// If there is no input in the system (p==0), this instruction has no effect
   virtual void setInput(const ObserverBase::InputVector & u_k, TimeIndex k);
+
+  /// @brief Set the input value at the next time indext
+  ///
+  /// @param u_k Value of the next input
+  virtual void pushInput(const ObserverBase::InputVector & u_k);
 
   /// Remove all the given past values of the inputs
   /// If there is no input, this instruction has no effect
@@ -96,6 +117,10 @@ public:
   ///
   /// This method sets the current time to k
   virtual ObserverBase::StateVector getEstimatedState(TimeIndex k);
+
+  /// @brief Get the Current Estimated State
+  /// @return ObserverBase::StateVector
+  virtual ObserverBase::StateVector getCurrentEstimatedState() const;
 
   /// Get the value of the current time index
   virtual TimeIndex getCurrentTime() const;

--- a/include/state-observation/observer/zero-delay-observer.hpp
+++ b/include/state-observation/observer/zero-delay-observer.hpp
@@ -101,6 +101,10 @@ public:
   /// If there is no input, this instruction has no effect
   virtual void clearInputs();
 
+  /// @brief  Remove all the given values of the inputs and measurements
+  ///
+  virtual void clearInputsAndMeasurements();
+
   /// @brief estimated State
   ///
   /// @param k The time index of the expected state value

--- a/include/state-observation/observer/zero-delay-observer.hpp
+++ b/include/state-observation/observer/zero-delay-observer.hpp
@@ -100,11 +100,19 @@ public:
   /// If there is no input, this instruction has no effect
   virtual void clearInputs();
 
-  /// Run the observer loop and gets the state estimation of the state at
-  /// instant k.
+  /// @brief estimated State
+  ///
+  /// @param k The time index of the expected state value
+  /// @return ObserverBase::StateVector
+  ///
+  /// @details If k is equal to the current time k_0, this will give the value of the last state/estimate.
+  ///
+  /// If k is larger than the current time k_0, this will run the observer loop and get the state estimation of the
+  /// state at instant k.
+  ///
   /// In order to estimate the state k, two conditions have to be met:
-  /// \li the time index k must be superior to the current time k_0, the
-  ///     does *not* record past values of the state and cannot observe
+  /// \li the time index k must be superior or equal to the current time k_0,
+  ///     the estimator does *not* record past values of the state and cannot observe
   ///     past states.
   /// \li the observer has to be able to reconstruct all the state
   ///     values from k_0 to k. That means all the measurements or input
@@ -113,7 +121,7 @@ public:
   /// That means generally (for most zero delay observers) that when
   /// current time is k_0 (we know an estimation of x_{k_0}) and we want
   /// to reconstruct the state at time k>k_0 we need to have the values of
-  /// y_{k_0+1} to y_{k} and u_{k_0} to u_{k-1}
+  /// y_{k_0+1} to y_{k} and u_{k_0} to u_{k-1} (or u_{k} depending on the measure dynamics)
   ///
   /// This method sets the current time to k
   virtual ObserverBase::StateVector getEstimatedState(TimeIndex k);
@@ -122,7 +130,7 @@ public:
   /// @return ObserverBase::StateVector
   virtual ObserverBase::StateVector getCurrentEstimatedState() const;
 
-  /// Get the value of the current time index
+  /// Get the value of the time index of the current state estimation
   virtual TimeIndex getCurrentTime() const;
 
   /// Get the value of the input of the time index k

--- a/include/state-observation/tools/definitions.hpp
+++ b/include/state-observation/tools/definitions.hpp
@@ -337,7 +337,7 @@ public:
   /// set the index of the matrix
   inline void setIndex(TimeIndex index);
 
-  /// Get the matrix value
+  /// Get the matrix value (const version)
   inline const MatrixType & operator()() const;
 
   /// Get the matrix value

--- a/misc-tools/real-offline-flexibility-estimator.cpp
+++ b/misc-tools/real-offline-flexibility-estimator.cpp
@@ -219,7 +219,7 @@ int test(const IndexedVectorArray & y, const IndexedVectorArray & u)
   std::ofstream f;
   f.open("trajectory.dat");
 
-  double error;
+  double error = 0;
 
   /// the reconstruction of the state
   for(TimeIndex i = y.getFirstIndex(); i < y.getNextIndex(); ++i)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set(HEADERS
     ${PROJECT_INCLUDE_DIR}/flexibility-estimation/imu-elastic-local-frame-dynamical-system.hpp
     ${PROJECT_INCLUDE_DIR}/dynamics-estimators/kinetics-observer.hpp
     ${PROJECT_INCLUDE_DIR}/dynamics-estimators/kinetics-observer.hxx
+    ${PROJECT_INCLUDE_DIR}/dynamics-estimators/lipm-dcm-bias-estimator.hpp
     ${PROJECT_INCLUDE_DIR}/examples/imu-attitude-trajectory-reconstruction.hpp
     ${PROJECT_INCLUDE_DIR}/examples/imu-attitude-trajectory-reconstruction.hxx
     ${PROJECT_INCLUDE_DIR}/examples/imu-multiplicative-attitude-reconstruction.hpp
@@ -96,7 +97,8 @@ set(SRC
     stable-imu-fixed-contact-dynamical-system.cpp
     imu-elastic-local-frame-dynamical-system.cpp
     bidim-elastic-inv-pendulum-dyn-sys.cpp
-    kinetics-observer.cpp)
+    kinetics-observer.cpp
+    lipm-dcm-bias-estimator.cpp)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
 add_library(${LIBRARY_NAME} SHARED ${SRC} ${HEADERS})

--- a/src/kalman-filter-base.cpp
+++ b/src/kalman-filter-base.cpp
@@ -88,6 +88,12 @@ void KalmanFilterBase::clearQ()
   q_.resize(0, 0);
 }
 
+void KalmanFilterBase::clearStates()
+{
+  ZeroDelayObserver::clearStates();
+  clearStateCovariance();
+}
+
 void KalmanFilterBase::setStateCovariance(const Pmatrix & P)
 {
   BOOST_ASSERT(checkPmatrix(P) && "ERROR: The P matrix dimensions are wrong");

--- a/src/linear-kalman-filter.cpp
+++ b/src/linear-kalman-filter.cpp
@@ -52,10 +52,9 @@ ObserverBase::StateVector LinearKalmanFilter::prediction_(TimeIndex k)
 ObserverBase::MeasureVector LinearKalmanFilter::simulateSensor_(const StateVector & x, TimeIndex k)
 {
 
-  BOOST_ASSERT(checkCmatrix(c_) && "ERROR: The C is not initialized");
-  BOOST_ASSERT(checkDmatrix(d_) && "ERROR: The D is not initialized");
+  BOOST_ASSERT(checkCmatrix(c_) && "ERROR: The C matrix is not initialized");
 
-  if(p_ > 0 && d_ != getDmatrixZero())
+  if(p_ > 0 && checkDmatrix(d_) && d_ != getDmatrixZero())
   {
     BOOST_ASSERT(u_.checkIndex(k)
                  && "ERROR: The input feedthrough of the measurements is not set "

--- a/src/linear-kalman-filter.cpp
+++ b/src/linear-kalman-filter.cpp
@@ -30,19 +30,19 @@ ObserverBase::StateVector LinearKalmanFilter::prediction_(TimeIndex k)
 {
   (void)k; // unused
 
-  BOOST_ASSERT(checkAmatrix(a_) && "ERROR: The A is not initialized");
-  BOOST_ASSERT(checkBmatrix(b_) && "ERROR: The B is not initialized");
-  BOOST_ASSERT(checkCmatrix(c_) && "ERROR: The C is not initialized");
-  BOOST_ASSERT(checkDmatrix(d_) && "ERROR: The D is not initialized");
+  BOOST_ASSERT(checkAmatrix(a_) && "ERROR: The A matrix is not initialized");
+  BOOST_ASSERT(checkBmatrix(b_) && "ERROR: The B matrix is not initialized");
+  BOOST_ASSERT(checkCmatrix(c_) && "ERROR: The C matrix is not initialized");
 
   xbar_.set(a_ * x_(), k);
 
   if(p_ > 0 && b_ != getBmatrixZero())
   {
-    BOOST_ASSERT(u_.checkIndex(k - 1) && "ERROR: The input feedthrough of the state dynamics is not set \
-                             (the state at time k+1 needs the input at time k which was not given) \
-                             if you don't need the input in the computation of state, you \
-                             must set B matrix to zero");
+    BOOST_ASSERT(u_.checkIndex(k - 1)
+                 && "ERROR: The input feedthrough of the state dynamics is not set "
+                    "(the state at time k+1 needs the input at time k which was not given) "
+                    "if you don't need the input in the computation of state, you "
+                    "must set B matrix to zero");
     xbar_().noalias() += b_ * this->u_[k - 1];
   }
 
@@ -57,15 +57,16 @@ ObserverBase::MeasureVector LinearKalmanFilter::simulateSensor_(const StateVecto
 
   if(p_ > 0 && d_ != getDmatrixZero())
   {
-    BOOST_ASSERT(u_.checkIndex(k) && "ERROR: The input feedthrough of the measurements is not set \
-                             (the measurement at time k needs the input at time k which was not given) \
-                             if you don't need the input in the computation of measurement, you \
-                             must set D matrix to zero");
+    BOOST_ASSERT(u_.checkIndex(k)
+                 && "ERROR: The input feedthrough of the measurements is not set "
+                    "(the measurement at time k needs the input at time k which was not given) "
+                    "if you don't need the input in the computation of measurement, you "
+                    "must set D matrix to zero");
     ybar_.set(c_ * x + d_ * u_[k], k);
   }
   else
   {
-    ybar_.set(ObserverBase::MeasureVector(c_ * x), k);
+    ybar_.set(c_ * x, k);
   }
   return ybar_();
 }

--- a/src/lipm-dcm-bias-estimator.cpp
+++ b/src/lipm-dcm-bias-estimator.cpp
@@ -1,0 +1,187 @@
+#include <state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp>
+#include <state-observation/tools/miscellaneous-algorithms.hpp>
+
+namespace stateObservation
+{
+using namespace tools;
+LipmDcmBiasEstimator::LipmDcmBiasEstimator(double omega_0,
+                                           double dt,
+                                           double biasDriftStd,
+                                           double zmpMeasureErrorStd,
+                                           double dcmMeasureErrorStd,
+                                           double initDcm,
+                                           double initBias,
+                                           double initDcmUncertainty,
+                                           double initBiasUncertainty)
+: omega0_(omega_0), dt_(dt), biasDriftStd_(biasDriftStd), zmpErrorStd_(zmpMeasureErrorStd), filter_(2, 1, 1)
+{
+  updateMatricesABQ_();
+  C_ << 1., 1.;
+  R_ << square(dcmMeasureErrorStd);
+  filter_.setC(C_);
+  filter_.setMeasurementCovariance(R_);
+  Vector2 x;
+  x << initDcm, initBias;
+  filter_.setState(x, 0);
+  Matrix2 P;
+  // clang-format off
+  P<< square(initDcmUncertainty),  0,
+      0,                           square(initBiasUncertainty);
+  // clang-format on
+  filter_.setStateCovariance(P);
+}
+
+LipmDcmBiasEstimator::LipmDcmBiasEstimator(bool measurementIsWithBias,
+                                           double measuredDcm,
+                                           double omega_0,
+                                           double dt,
+                                           double biasDriftStd,
+                                           double zmpMeasureErrorStd,
+                                           double dcmMeasureErrorStd,
+                                           double initBias,
+                                           double initBiasuncertainty)
+: omega0_(omega_0), dt_(dt), biasDriftStd_(biasDriftStd), zmpErrorStd_(zmpMeasureErrorStd), filter_(2, 1, 1)
+{
+  updateMatricesABQ_();
+  C_ << 1., 1.;
+  R_ << square(dcmMeasureErrorStd);
+  filter_.setC(C_);
+  filter_.setMeasurementCovariance(R_);
+  Vector2 x;
+
+  /// initialize the state using the measurement
+  if(measurementIsWithBias)
+  {
+    x << measuredDcm - initBias, initBias;
+  }
+  else
+  {
+    x << measuredDcm, initBias;
+  }
+
+  filter_.setState(x, 0);
+  Matrix2 P;
+
+  if(measurementIsWithBias)
+  {
+    /// The state and the
+    // clang-format off
+    P<< square(dcmMeasureErrorStd) + square(initBiasuncertainty),  -square(initBiasuncertainty),
+        -square(initBiasuncertainty),                               square(initBiasuncertainty);
+    // clang-format on
+  }
+  else
+  {
+    // clang-format off
+    P<< square(dcmMeasureErrorStd),  0,
+        0,                           square(initBiasuncertainty);
+    // clang-format on
+  }
+
+  filter_.setStateCovariance(P);
+}
+
+LipmDcmBiasEstimator::~LipmDcmBiasEstimator() {}
+
+void LipmDcmBiasEstimator::setLipmNaturalFrequency(double omega_0)
+{
+  omega0_ = omega_0;
+  updateMatricesABQ_();
+}
+
+void LipmDcmBiasEstimator::setSamplingTime(double dt)
+{
+  dt_ = dt;
+  updateMatricesABQ_();
+}
+
+void LipmDcmBiasEstimator::setBias(double bias)
+{
+  Vector2 x = filter_.getCurrentEstimatedState();
+  /// update the bias
+  x(1) = bias;
+  filter_.setCurrentState(x);
+}
+
+void LipmDcmBiasEstimator::setBias(double bias, double uncertainty)
+{
+  setBias(bias);
+  Matrix2 P = filter_.getStateCovariance();
+  /// resetting the non diagonal parts
+  P(0, 1) = P(1, 0) = 0;
+  P(1, 1) = square(uncertainty);
+  filter_.setStateCovariance(P);
+}
+
+void LipmDcmBiasEstimator::setBiasDriftPerSecond(double driftPerSecond)
+{
+  Matrix2 Q = filter_.getProcessCovariance();
+  /// update the corresponding part in the process noise matrix
+  Q(1, 1) = square(driftPerSecond);
+  filter_.setProcessCovariance(Q);
+}
+
+void LipmDcmBiasEstimator::setDCM(double dcm)
+{
+  Vector2 x = filter_.getCurrentEstimatedState();
+  /// update the bias
+  x(0) = dcm;
+  filter_.setCurrentState(x);
+}
+
+void LipmDcmBiasEstimator::setDCM(double dcm, double uncertainty)
+{
+  setDCM(dcm);
+  Matrix2 P = filter_.getStateCovariance();
+  /// resetting the non diagonal parts
+  P(0, 1) = P(1, 0) = 0;
+  P(0, 0) = square(uncertainty);
+  filter_.setStateCovariance(P);
+}
+
+void LipmDcmBiasEstimator::setZmpMeasureErrorStd(double std)
+{
+  zmpErrorStd_ = std;
+  updateMatricesABQ_();
+}
+
+void LipmDcmBiasEstimator::setDcmMeasureErrorStd(double std)
+{
+  Matrix1 R;
+  R(0, 0) = square(std);
+}
+
+void LipmDcmBiasEstimator::setInputs(double dcm, double zmp)
+{
+  Vector1 u;
+  Vector1 y;
+  u(0) = zmp;
+  y(0) = dcm;
+  filter_.pushMeasurement(y);
+  filter_.pushInput(u);
+}
+
+double LipmDcmBiasEstimator::getUnbiasedDCM() const
+{
+  return filter_.getCurrentEstimatedState()(0);
+}
+
+void LipmDcmBiasEstimator::LipmDcmBiasEstimator::updateMatricesABQ_()
+{
+  // clang-format off
+  A_ << 1 + omega0_ * dt_, 0,
+        0,                 1;
+
+  B_ << -omega0_ * dt_,
+        0;
+
+  Q_ << square(omega0_* dt_ * zmpErrorStd_), 0,
+        0,                                   square(biasDriftStd_);
+  // clang-format on
+
+  filter_.setA(A_);
+  filter_.setB(B_);
+  filter_.setStateCovariance(Q_);
+}
+
+} // namespace stateObservation

--- a/src/lipm-dcm-bias-estimator.cpp
+++ b/src/lipm-dcm-bias-estimator.cpp
@@ -49,7 +49,7 @@ LipmDcmBiasEstimator::LipmDcmBiasEstimator(bool measurementIsWithBias,
   updateMatricesABQ_();
   C_ << 1., 1.;
   R_ << square(dcmMeasureErrorStd);
-  filter_.setC(C_);
+  filter_.setC(C_.transpose());
   filter_.setMeasurementCovariance(R_);
   Vector2 x;
 
@@ -185,12 +185,12 @@ void LipmDcmBiasEstimator::LipmDcmBiasEstimator::updateMatricesABQ_()
         0;
 
   Q_ << square(omega0_* dt_ * zmpErrorStd_), 0,
-        0,                                   square(biasDriftStd_);
+        0,                                   square(biasDriftStd_*dt_);
   // clang-format on
 
   filter_.setA(A_);
   filter_.setB(B_);
-  filter_.setStateCovariance(Q_);
+  filter_.setProcessCovariance(Q_);
 }
 
 } // namespace stateObservation

--- a/src/lipm-dcm-bias-estimator.cpp
+++ b/src/lipm-dcm-bias-estimator.cpp
@@ -175,6 +175,11 @@ double LipmDcmBiasEstimator::getUnbiasedDCM() const
   return filter_.getCurrentEstimatedState()(0);
 }
 
+double LipmDcmBiasEstimator::getBias() const
+{
+  return filter_.getCurrentEstimatedState()(1);
+}
+
 void LipmDcmBiasEstimator::LipmDcmBiasEstimator::updateMatricesABQ_()
 {
   // clang-format off

--- a/src/observer-base.cpp
+++ b/src/observer-base.cpp
@@ -3,13 +3,6 @@
 namespace stateObservation
 {
 
-void ObserverBase::reset()
-{
-  clearStates();
-  clearMeasurements();
-  clearInputs();
-}
-
 ObserverBase::ObserverBase()
 {
   n_ = m_ = p_ = 0;
@@ -75,6 +68,13 @@ ObserverBase::InputVector ObserverBase::inputVectorZero() const
 bool ObserverBase::checkInputVector(const InputVector & v) const
 {
   return (v.rows() == p_ && v.cols() == 1);
+}
+
+void ObserverBase::reset()
+{
+  clearStates();
+  clearMeasurements();
+  clearInputs();
 }
 
 void ObserverBase::setStateSize(Index n)

--- a/src/observer-base.cpp
+++ b/src/observer-base.cpp
@@ -70,6 +70,12 @@ bool ObserverBase::checkInputVector(const InputVector & v) const
   return (v.rows() == p_ && v.cols() == 1);
 }
 
+void ObserverBase::clearInputsAndMeasurements()
+{
+  clearMeasurements();
+  clearInputs();
+}
+
 void ObserverBase::reset()
 {
   clearStates();

--- a/src/zero-delay-observer.cpp
+++ b/src/zero-delay-observer.cpp
@@ -109,7 +109,13 @@ void ZeroDelayObserver::pushInput(const ObserverBase::InputVector & u_k)
 
 void ZeroDelayObserver::clearInputs()
 {
-  if(p_ > 0) u_.reset();
+  u_.reset();
+}
+
+void ZeroDelayObserver::clearInputsAndMeasurements()
+{
+  u_.reset();
+  y_.reset();
 }
 
 ObserverBase::StateVector ZeroDelayObserver::getEstimatedState(TimeIndex k)

--- a/src/zero-delay-observer.cpp
+++ b/src/zero-delay-observer.cpp
@@ -112,7 +112,7 @@ void ZeroDelayObserver::clearInputs()
   if(p_ > 0) u_.reset();
 }
 
-ObserverBase::StateVector ZeroDelayObserver::estimateState(TimeIndex k)
+ObserverBase::StateVector ZeroDelayObserver::getEstimatedState(TimeIndex k)
 {
   BOOST_ASSERT(x_.isSet() && "The state vector has not been set");
 

--- a/src/zero-delay-observer.cpp
+++ b/src/zero-delay-observer.cpp
@@ -153,14 +153,9 @@ TimeSize ZeroDelayObserver::getInputsNumber() const
 
 TimeIndex ZeroDelayObserver::getInputTime() const
 {
-  if(u_.size() > 0)
-  {
-    return u_.getLastIndex();
-  }
-  else
-  {
-    return 0;
-  }
+
+  BOOST_ASSERT(y_.size() > 0 && "ERROR: There is no measurements registered (past measurements are erased)");
+  return u_.getLastIndex();
 }
 
 Vector ZeroDelayObserver::getMeasurement(TimeIndex k) const

--- a/src/zero-delay-observer.cpp
+++ b/src/zero-delay-observer.cpp
@@ -112,7 +112,7 @@ void ZeroDelayObserver::clearInputs()
   if(p_ > 0) u_.reset();
 }
 
-ObserverBase::StateVector ZeroDelayObserver::getEstimatedState(TimeIndex k)
+ObserverBase::StateVector ZeroDelayObserver::estimateState(TimeIndex k)
 {
   BOOST_ASSERT(x_.isSet() && "The state vector has not been set");
 

--- a/src/zero-delay-observer.cpp
+++ b/src/zero-delay-observer.cpp
@@ -114,7 +114,9 @@ void ZeroDelayObserver::clearInputs()
 
 ObserverBase::StateVector ZeroDelayObserver::getEstimatedState(TimeIndex k)
 {
-  TimeIndex k0 = x_.getTime();
+  BOOST_ASSERT(x_.isSet() && "The state vector has not been set");
+
+  TimeIndex k0 = getCurrentTime();
 
   BOOST_ASSERT(k0 <= k && "ERROR: The observer cannot estimate previous states");
 
@@ -138,6 +140,7 @@ ObserverBase::StateVector ZeroDelayObserver::getCurrentEstimatedState() const
 
 TimeIndex ZeroDelayObserver::getCurrentTime() const
 {
+  BOOST_ASSERT(x_.isSet() && "The state vector has not been set");
   return x_.getTime();
 }
 

--- a/src/zero-delay-observer.cpp
+++ b/src/zero-delay-observer.cpp
@@ -59,7 +59,7 @@ void ZeroDelayObserver::pushMeasurement(const ObserverBase::MeasureVector & y_k)
   {
     BOOST_ASSERT(x_.isSet()
                  && "Unable to initialize measurement without time index, the state vector has not been set.");
-
+    /// we need the measurement of the next state to correct for the prediction
     y_.setValue(y_k, x_.getTime() + 1);
   }
 }
@@ -102,7 +102,8 @@ void ZeroDelayObserver::pushInput(const ObserverBase::InputVector & u_k)
     else
     {
       BOOST_ASSERT(x_.isSet() && "Unable to initialize input without time index, the state vector has not been set.");
-      u_.setValue(u_k, x_.getTime() + 1);
+      /// we need the input at the time of the state vector to predict the next one
+      u_.setValue(u_k, x_.getTime());
     }
   }
 }

--- a/unit-testings/CMakeLists.txt
+++ b/unit-testings/CMakeLists.txt
@@ -20,6 +20,7 @@ add_so_test(other-tests)
 add_so_test(test_acceleration_stabilization)
 add_so_test(test_model-base-ekf-flex-estimator-imu)
 add_so_test(test-kinetics-observer)
+add_so_test(test-dcm-bias-estimation)
 
 add_custom_command(
   TARGET test_model-base-ekf-flex-estimator-imu

--- a/unit-testings/test-dcm-bias-estimation.cpp
+++ b/unit-testings/test-dcm-bias-estimation.cpp
@@ -1,0 +1,132 @@
+#include <iostream>
+#include <state-observation/dynamics-estimators/lipm-dcm-bias-estimator.hpp>
+#include <state-observation/tools/probability-law-simulation.hpp>
+
+using namespace stateObservation;
+
+/// @brief runs the basic test
+///
+/// @return int : 0 if success, nonzero if fails
+int testDcmBiasEstimator()
+{
+
+  double w0 = sqrt(cst::gravityConstant / 0.9);
+  double dt = 0.005;
+
+  double biasDriftPerSecondStd = 0.005;
+  double zmpMeasurementErrorStd = 0.001;
+  double dcmMeasurementErrorStd = 0.005;
+
+  int signallength = int(120. / dt);
+
+  ///////////////////////////////////////
+  /// Build the ground truth signals
+  ///////////////////////////////////////
+  tools::ProbabilityLawSimulation ran;
+  std::vector<double> dcm(signallength), bias(signallength), zmp(signallength);
+
+  /// set the desired exponential convergence of the DCM
+  double lambda = 2;
+
+  /// initialize the dcm and bias to a random value
+  dcm[0] = ran.getGaussianScalar(2, 0);
+  double initBiasstd = 0.01;
+
+  bias[0] = ran.getGaussianScalar(0.01, 0);
+  double deviation = ran.getGaussianScalar(0.05, 0);
+  zmp[0] = (lambda / w0 + 1) * dcm[0] + deviation;
+
+  for(int i = 0; i < signallength - 1; ++i)
+  {
+    /// dcm dynamics
+    dcm[i + 1] = dcm[i] + dt * w0 * (dcm[i] - zmp[i]);
+    /// drift
+    bias[i + 1] = bias[i] + ran.getGaussianScalar(biasDriftPerSecondStd * dt);
+    /// set a noisy zmp to create  bounded drift of the DCM
+    deviation += ran.getGaussianScalar(0.05, 0);
+    zmp[i + 1] = (lambda / w0 + 1) * dcm[i] + ran.getGaussianScalar(0.05, 0) + deviation;
+  }
+
+  /////////////////////////////////
+  /// Build the measurements
+  /////////////////////////////////
+  std::vector<double> dcm_m_unbiased(signallength), dcm_m(signallength), zmp_m(signallength);
+
+  for(int i = 0; i < signallength; ++i)
+  {
+    dcm_m_unbiased[i] = dcm[i] + ran.getGaussianScalar(dcmMeasurementErrorStd);
+    dcm_m[i] = dcm_m_unbiased[i] + bias[i];
+    zmp_m[i] = zmp[i] + ran.getGaussianScalar(zmpMeasurementErrorStd);
+  }
+
+  /////////////////////////////////
+  /// Run the estimator
+  /////////////////////////////////
+  std::vector<double> dcm_hat(signallength), bias_hat(signallength);
+
+  double initbias = 0;
+
+  LipmDcmBiasEstimator est(true, dcm_m[0], zmp_m[0], w0, dt, biasDriftPerSecondStd, zmpMeasurementErrorStd,
+                           dcmMeasurementErrorStd, initbias, initBiasstd);
+
+  IndexedVectorArray log;
+
+  for(int i = 1; i < signallength; i++)
+  {
+    est.setInputs(dcm_m[i], zmp_m[i]);
+    est.update();
+    bias_hat[i] = est.getBias();
+    dcm_hat[i] = est.getUnbiasedDCM();
+
+    /// NaN detection
+    if(dcm_hat[i] != dcm_hat[i])
+    {
+      return 1;
+    }
+
+    Vector6 log_k;
+
+    log_k << i, bias_hat[i], bias[i], dcm_hat[i], dcm_m_unbiased[i], dcm[i];
+    log.pushBack(log_k);
+  }
+
+  /// uncomment the following line to have a bit of a log
+  // log.writeInFile("dcm.txt");
+
+  /////////////////////////////////
+  /// Check the rror
+  /////////////////////////////////
+  double error = 0;
+
+  for(int i = signallength - 10; i < signallength; ++i)
+  {
+    error += fabs(dcm_hat[i] - dcm[i]) + fabs(bias_hat[i] - bias[i]);
+  }
+
+  std::cout << "Sum of error on the 10 last samples = " << error << std::endl;
+
+  if(error > 0.02)
+  {
+    return 2;
+  }
+  else
+  {
+    return 0;
+  }
+}
+
+int main()
+{
+  int exitCode;
+
+  exitCode = testDcmBiasEstimator();
+
+  if(exitCode != 0)
+  {
+    std::cout << "Failed, error code: " << exitCode << std::endl;
+    return exitCode;
+  }
+
+  std::cout << "Succeeded" << std::endl;
+  return exitCode;
+}


### PR DESCRIPTION
This PR gives a new estimator able to
-Reject the bias that can alter the measured position of the DCM 
-Filter the DCM using the measurements of the zmp for cleaner high frequencies.

