### PR TITLE
[mergeTiltWithYawAxisAgnostic] normalize horizontal vector

### DIFF
--- a/include/state-observation/tools/rigid-body-kinematics.hxx
+++ b/include/state-observation/tools/rigid-body-kinematics.hxx
@@ -385,7 +385,7 @@ namespace stateObservation
 
     inline Matrix3 mergeTiltWithYawAxisAgnostic(const Vector3 & Rtez, const Matrix3 & R2)
     {
-      return mergeTiltWithYaw(Rtez, R2, getInvariantHorizontalVector(R2));
+      return mergeTiltWithYaw(Rtez, R2, getInvariantHorizontalVector(R2).normalized());
     }
 
     inline Matrix3 mergeRoll1Pitch1WithYaw2AxisAgnostic(const Matrix3 & R1, const Matrix3 & R2)


### PR DESCRIPTION
This patch is required to maintain the consistency of following four points.

https://github.com/jrl-umi3218/state-observation/blob/4a6b8eb6fa841cf706a074132fb24b50e8534e35/include/state-observation/tools/rigid-body-kinematics.hpp#L168

https://github.com/jrl-umi3218/state-observation/blob/4a6b8eb6fa841cf706a074132fb24b50e8534e35/include/state-observation/tools/rigid-body-kinematics.hpp#L155

https://github.com/jrl-umi3218/state-observation/blob/4a6b8eb6fa841cf706a074132fb24b50e8534e35/include/state-observation/tools/rigid-body-kinematics.hxx#L388

https://github.com/jrl-umi3218/state-observation/blob/4a6b8eb6fa841cf706a074132fb24b50e8534e35/include/state-observation/tools/rigid-body-kinematics.hxx#L322-L332