### PR TITLE
[cmake] Correct the configuration method for the testing time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,16 +60,21 @@ else()
   add_project_dependency(Eigen3 MODULE REQUIRED)
 endif()
 
+
+set(TEST_COMPUTATION_TIME "OFF")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/state-observation/config.h.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/include/state-observation/config.h.in" @ONLY)
+
 file(
   GENERATE
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/include/state-observation/config.h"
-  INPUT "${CMAKE_CURRENT_SOURCE_DIR}/include/state-observation/config.h.in")
+  INPUT "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/include/state-observation/config.h.in")
 install(FILES "${CMAKE_BINARY_DIR}/$<CONFIG>/include/state-observation/config.h"
         DESTINATION ${INCLUDE_INSTALL_DESTINATION})
 
 add_subdirectory(src)
 
-set(TEST_COMPUTATION_TIME false)
+
 if(BUILD_TESTING)
   add_subdirectory(unit-testings)
 endif()

--- a/include/state-observation/config.h.in
+++ b/include/state-observation/config.h.in
@@ -1,7 +1,9 @@
 namespace stateObservation
 {
-	constexpr bool Release_BUILD=$<CONFIG:Release>;
-	constexpr bool Debug_BUILD=$<CONFIG:Debug>;
-	constexpr bool RelWithDebInfo_BUILD=$<CONFIG:RelWithDebInfo>;
-  constexpr bool TEST_COMPUTATION_TIME = "${TEST_COMPUTATION_TIME}/" ;
+// clang-format off
+  constexpr bool Release_BUILD = $<CONFIG:Release>;
+  constexpr bool Debug_BUILD = $<CONFIG:Debug>;
+  constexpr bool RelWithDebInfo_BUILD = $<CONFIG:RelWithDebInfo>;
+  constexpr bool TEST_COMPUTATION_TIME = $<BOOL:@TEST_COMPUTATION_TIME@>;
+// clang-format on
 }


### PR DESCRIPTION
The previous method was always running the test