### PR TITLE
[dcm] Add support for CoM offset, and ZMP coefficient

### DIFF
--- a/doc/pages/biblio.bib
+++ b/doc/pages/biblio.bib
@@ -1,0 +1,10 @@
+@article{murooka2021humanoid,
+  title={Humanoid Loco-Manipulations Pattern Generation and Stabilization Control},
+  author={Murooka, Masaki and Chappellet, Kevin and Tanguy, Arnaud and Benallegue, Mehdi and Kumagai, Iori and Morisawa, Mitsuharu and Kanehiro, Fumio and Kheddar, Abderrahmane},
+  journal={IEEE Robotics and Automation Letters},
+  volume={6},
+  number={3},
+  pages={5597--5604},
+  year={2021},
+  publisher={IEEE}
+}

--- a/doc/pages/dcm-bias-estimator.html
+++ b/doc/pages/dcm-bias-estimator.html
@@ -2050,6 +2050,207 @@ Which gives
 <div class="Indented">
 Note that in this case we consider that the rotation signal <span class="formula"><i>R</i></span> is noiseless.
 </div>
+<h2 class="Section">
+<a class="toc" name="toc-Section-2.6">2.6</a> Consider CoM offset and ZMP coefficient
+</h2>
+<div class="Unindented">
+What if we can measure in the DCM dynamics an offset on the CoM and a coefficient to the ZMP ? In other words the dynamics of the DCM becomes <div class="formula">
+<a class="eqnumber" name="eq-2.15">(2.15) </a><span class="environment"><span class="arrayrow">
+<span class="arraycell align-r">
+<i>ξ̇</i>
+</span>
+<span class="arraycell align-l">
+ = <i>ω</i><sub>0</sub>(<i>ξ</i> − <i>κ</i><i>z</i> + <i>γ</i>)
+</span>
+
+</span>
+</span>
+</div>
+
+</div>
+<div class="Indented">
+wherev <span class="formula"><i>α</i></span> is the CoM offset and \strikeout off\xout off\uuline off\uwave off<span class="formula"><i>κ</i></span> is the ZMP coefficient, they are considered known. This may happen in the presence of planned or measured contact forces (see equation (8) in <span class="bibcites">[<a class="bibliocite" name="cite-1" href="#biblio-1"><span class="bib-index">1</span></a>]</span>).
+</div>
+<div class="Indented">
+This can be discretized as <div class="formula">
+<a class="eqnumber" name="eq-2.16">(2.16) </a><span class="environment"><span class="arrayrow">
+<span class="arraycell align-r">
+<i>ξ</i><sub><i>k</i> + 1</sub>
+</span>
+<span class="arraycell align-l">
+ = <i>ξ</i><sub><i>k</i></sub> + <i>ω</i><sub>0</sub><i>T</i>(<i>ξ</i><sub><i>k</i></sub> − <i>κ</i><i>z</i><sub><i>k</i></sub> + <i>γ</i>)
+</span>
+
+</span>
+</span>
+</div>
+
+</div>
+<div class="Indented">
+Which gives
+</div>
+<div class="Indented">
+<div class="formula">
+<a class="eqnumber" name="eq-2.17">(2.17) </a><span class="environment"><span class="arrayrow">
+<span class="arraycell align-r">
+<span class="array"><span class="arrayrow"><span class="bracket align-left">⎛</span></span><span class="arrayrow"><span class="bracket align-left">⎜</span></span><span class="arrayrow"><span class="bracket align-left">⎝</span></span></span><span class="array"><span class="arrayrow">
+<span class="arraycell align-c">
+<i>ξ</i><sub><i>k</i> + 1</sub>
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+ 
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+<i>b</i><sub><i>k</i> + 1</sub>
+</span>
+
+</span>
+</span><span class="array"><span class="arrayrow"><span class="bracket align-right">⎞</span></span><span class="arrayrow"><span class="bracket align-right">⎟</span></span><span class="arrayrow"><span class="bracket align-right">⎠</span></span></span>
+</span>
+<span class="arraycell align-l">
+ = <span class="array"><span class="arrayrow"><span class="bracket align-left">⎛</span></span><span class="arrayrow"><span class="bracket align-left">⎜</span></span><span class="arrayrow"><span class="bracket align-left">⎝</span></span></span><span class="array"><span class="arrayrow">
+<span class="arraycell align-c">
+<span class="symbol">(</span>1 + <i>ω</i><sub>0</sub><i>T</i><span class="symbol">)</span><i>I</i><sub>2 × 2</sub>
+</span>
+<span class="arraycell align-c">
+0
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+ 
+</span>
+<span class="arraycell align-c">
+ 
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+0
+</span>
+<span class="arraycell align-c">
+<i>R</i><sub><i>k</i> + 1</sub><i>R</i><span class="scripts"><sup class="script"><i>T</i></sup><sub class="script"><i>k</i></sub></span>
+</span>
+
+</span>
+</span><span class="array"><span class="arrayrow"><span class="bracket align-right">⎞</span></span><span class="arrayrow"><span class="bracket align-right">⎟</span></span><span class="arrayrow"><span class="bracket align-right">⎠</span></span></span><span class="array"><span class="arrayrow"><span class="bracket align-left">⎛</span></span><span class="arrayrow"><span class="bracket align-left">⎜</span></span><span class="arrayrow"><span class="bracket align-left">⎝</span></span></span><span class="array"><span class="arrayrow">
+<span class="arraycell align-c">
+<i>ξ</i><sub><i>k</i></sub>
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+ 
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+<i>b</i><sub><i>k</i></sub>
+</span>
+
+</span>
+</span><span class="array"><span class="arrayrow"><span class="bracket align-right">⎞</span></span><span class="arrayrow"><span class="bracket align-right">⎟</span></span><span class="arrayrow"><span class="bracket align-right">⎠</span></span></span> + <span class="array"><span class="arrayrow"><span class="bracket align-left">⎛</span></span><span class="arrayrow"><span class="bracket align-left">⎜</span></span><span class="arrayrow"><span class="bracket align-left">⎝</span></span></span><span class="array"><span class="arrayrow">
+<span class="arraycell align-c">
+ − <i>ω</i><sub>0</sub><i>T</i><i>κ</i><i>I</i><sub>2 × 2</sub>
+</span>
+<span class="arraycell align-c">
+
+</span>
+<span class="arraycell align-c">
+<i>ω</i><sub>0</sub><i>TI</i><sub>2 × 2</sub>
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+ 
+</span>
+<span class="arraycell align-c">
+ 
+</span>
+<span class="arraycell align-c">
+ 
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+0
+</span>
+<span class="arraycell align-c">
+
+</span>
+<span class="arraycell align-c">
+0
+</span>
+
+</span>
+</span><span class="array"><span class="arrayrow"><span class="bracket align-right">⎞</span></span><span class="arrayrow"><span class="bracket align-right">⎟</span></span><span class="arrayrow"><span class="bracket align-right">⎠</span></span></span><span class="array"><span class="arrayrow"><span class="bracket align-left">⎛</span></span><span class="arrayrow"><span class="bracket align-left">⎜</span></span><span class="arrayrow"><span class="bracket align-left">⎝</span></span></span><span class="array"><span class="arrayrow">
+<span class="arraycell align-c">
+<i>ẑ</i><sub><i>k</i></sub>
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+ 
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+<i>γ</i>
+</span>
+
+</span>
+</span><span class="array"><span class="arrayrow"><span class="bracket align-right">⎞</span></span><span class="arrayrow"><span class="bracket align-right">⎟</span></span><span class="arrayrow"><span class="bracket align-right">⎠</span></span></span> + <span class="array"><span class="arrayrow"><span class="bracket align-left">⎛</span></span><span class="arrayrow"><span class="bracket align-left">⎜</span></span><span class="arrayrow"><span class="bracket align-left">⎝</span></span></span><span class="array"><span class="arrayrow">
+<span class="arraycell align-c">
+<i>ω</i><sub>0</sub><i>Tw</i><sup><i>z</i></sup>
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+ 
+</span>
+
+</span>
+<span class="arrayrow">
+<span class="arraycell align-c">
+<i>v</i><sub><i>k</i></sub>
+</span>
+
+</span>
+</span><span class="array"><span class="arrayrow"><span class="bracket align-right">⎞</span></span><span class="arrayrow"><span class="bracket align-right">⎟</span></span><span class="arrayrow"><span class="bracket align-right">⎠</span></span></span>
+</span>
+
+</span>
+</span>
+</div>
+
+</div>
+<div class="Indented">
+Which is implemented in the code
+</div>
+<div class="Indented">
+\strikeout off\xout off\uuline off\uwave off<h1 class="biblio">
+Bibliography
+</h1>
+<p class="biblio">
+<span class="entry">[<a class="biblioentry" name="biblio-1"><span class="bib-index">1</span></a>] </span> <span class="bib-authors">Masaki Murooka, Kevin Chappellet, Arnaud Tanguy, Mehdi Benallegue, Iori Kumagai, Mitsuharu Morisawa, Fumio Kanehiro, Abderrahmane Kheddar</span>. <span class="bib-title">Humanoid Loco-Manipulations Pattern Generation and Stabilization Control</span>. <i><span class="bib-journal">IEEE Robotics and Automation Letters</span></i>, <span class="bib-volume">6</span>(<span class="bib-number">3</span>):<span class="bib-pages">5597—5604</span>, <span class="bib-year">2021</span>.
+</p>
+
+</div>
 <h1 class="Chapter">
 <a class="toc" name="toc-Appendix-A">A</a> Unit-testing code
 </h1>
@@ -2108,6 +2309,10 @@ We wish to generate a random trajectory for the dcm but with bounded values. Let
 
 </div>
 
+<hr class="footer"/>
+<div class="footer" id="generated-by">
+Document generated by <a href="http://elyxer.nongnu.org/">eLyXer 1.2.5 (2013-03-10)</a> on <span class="create-date">2022-10-22T18:01:32.718000</span>
+</div>
 </div>
 </body>
 </html>

--- a/doc/pages/dcm-bias-estimator.lyx
+++ b/doc/pages/dcm-bias-estimator.lyx
@@ -2268,8 +2268,8 @@ We wish to generate a random trajectory for the dcm but with bounded values.
 \begin_inset Formula 
 \begin{align}
 \dot{\xi}^{d} & =-\lambda\xi\\
-\omega_{0}\left(\xi-z^{d}\right) & =-\lambda\xi\\
-z^{d} & =\left(\frac{\lambda}{\omega_{0}}+1\right)\xi
+\omega_{0}(\xi-\kappa z+\gamma) & =-\lambda\xi\\
+z^{d} & =\frac{1}{\kappa}\left(\left(\frac{\lambda}{\omega_{0}}+1\right)\xi+\gamma\right)
 \end{align}
 
 \end_inset

--- a/doc/pages/dcm-bias-estimator.lyx
+++ b/doc/pages/dcm-bias-estimator.lyx
@@ -1,5 +1,5 @@
 #LyX 2.4 created this file. For more info see https://www.lyx.org/
-\lyxformat 544
+\lyxformat 600
 \begin_document
 \begin_header
 \save_transient_properties true
@@ -9,11 +9,11 @@
 \usepackage{hyperref}
 \end_preamble
 \use_default_options true
-\maintain_unincluded_children false
+\maintain_unincluded_children no
 \language american
 \language_package default
 \inputencoding utf8
-\fontencoding global
+\fontencoding auto
 \font_roman "default" "default"
 \font_sans "default" "default"
 \font_typewriter "default" "default"
@@ -21,7 +21,9 @@
 \font_default_family default
 \use_non_tex_fonts false
 \font_sc false
-\font_osf false
+\font_roman_osf false
+\font_sans_osf false
+\font_typewriter_osf false
 \font_sf_scale 100 100
 \font_tt_scale 100 100
 \use_microtype false
@@ -56,6 +58,7 @@
 \justification true
 \use_refstyle 1
 \use_minted 0
+\use_lineno 0
 \index Index
 \shortcut idx
 \color #b5bd68
@@ -71,11 +74,15 @@
 \papercolumns 1
 \papersides 1
 \paperpagestyle default
+\tablestyle default
 \tracking_changes false
 \output_changes false
+\change_bars false
+\postpone_fragile_content false
 \html_math_output 0
 \html_css_as_file 0
 \html_be_strict false
+\docbook_table_output 0
 \end_header
 
 \begin_body
@@ -95,6 +102,7 @@ Definitions
 \begin_layout Standard
 \begin_inset Float table
 placement H
+alignment document
 wide false
 sideways false
 status open
@@ -664,6 +672,7 @@ Variable definition
 \begin_layout Standard
 \begin_inset Float table
 placement H
+alignment document
 wide false
 sideways false
 status open
@@ -1072,6 +1081,7 @@ s and
 \begin_layout Standard
 \begin_inset Float table
 placement H
+alignment document
 wide false
 sideways false
 status open
@@ -1641,6 +1651,7 @@ Variable definition
 \begin_layout Standard
 \begin_inset Float table
 placement H
+alignment document
 wide false
 sideways false
 status open
@@ -2115,6 +2126,131 @@ Note that in this case we consider that the rotation signal
 \end_inset
 
  is noiseless.
+\end_layout
+
+\begin_layout Section
+Consider CoM offset and ZMP coefficient
+\end_layout
+
+\begin_layout Standard
+What if we can measure in the DCM dynamics an offset on the CoM and a coefficien
+t to the ZMP ? In other words the dynamics of the DCM becomes 
+\begin_inset Formula 
+\begin{align}
+\dot{\xi} & =\omega_{0}(\xi-\kappa z+\gamma)
+\end{align}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+wherev 
+\begin_inset Formula $\alpha$
+\end_inset
+
+ is the CoM offset and 
+\family roman
+\series medium
+\shape up
+\size normal
+\emph off
+\nospellcheck off
+\bar no
+\strikeout off
+\xout off
+\uuline off
+\uwave off
+\noun off
+\color none
+
+\begin_inset Formula $\kappa$
+\end_inset
+
+ is the ZMP coefficient, they are considered known.
+ This may happen in the presence of planned or measured contact forces (see
+ equation (8) in 
+\begin_inset CommandInset citation
+LatexCommand cite
+key "murooka2021humanoid"
+literal "false"
+
+\end_inset
+
+).
+\end_layout
+
+\begin_layout Standard
+This can be discretized as 
+\begin_inset Formula 
+\begin{align}
+\xi_{k+1} & =\xi_{k}+\omega_{0}T(\xi_{k}-\kappa z_{k}+\gamma)
+\end{align}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Which gives
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\begin{align}
+\left(\begin{array}{c}
+\xi_{k+1}\\
+b_{k+1}
+\end{array}\right) & =\left(\begin{matrix}\left(1+\omega_{0}T\right)I_{2\times2} & 0\\
+0 & R_{k+1}R_{k}^{T}
+\end{matrix}\right)\left(\begin{array}{c}
+\xi_{k}\\
+b_{k}
+\end{array}\right)+\left(\begin{matrix}-\omega_{0}T\kappa I_{2\times2} &  & \omega_{0}TI_{2\times2}\\
+0 &  & 0
+\end{matrix}\right)\left(\begin{matrix}\hat{z}_{k}\\
+\gamma
+\end{matrix}\right)+\left(\begin{matrix}\omega_{0}Tw^{z}\\
+v_{k}
+\end{matrix}\right)
+\end{align}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Which is implemented in the code
+\end_layout
+
+\begin_layout Standard
+
+\family roman
+\series medium
+\shape up
+\size normal
+\emph off
+\nospellcheck off
+\bar no
+\strikeout off
+\xout off
+\uuline off
+\uwave off
+\noun off
+\color none
+\begin_inset CommandInset bibtex
+LatexCommand bibtex
+btprint "btPrintCited"
+bibfiles "biblio"
+options "plain"
+encoding "default"
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Chapter

--- a/include/state-observation/dynamics-estimators/lipm-dcm-estimator.hpp
+++ b/include/state-observation/dynamics-estimators/lipm-dcm-estimator.hpp
@@ -148,7 +148,7 @@ public:
   /// @param initBiasuncertainty    the uncertainty in the bias initial value in meters
   inline void resetWithMeasurements(const Vector2 & measuredDcm,
                                     const Vector2 & measuredZMP,
-                                    double yaw = 0,
+                                    double yaw,
                                     bool measurementIsWithBias = true,
                                     const Vector2 & initBias = Vector2::Constant(0),
                                     const Vector2 & initBiasuncertainty = Vector2::Constant(defaultBiasUncertainty))
@@ -171,7 +171,7 @@ public:
   /// @param initBiasuncertainty    the uncertainty in the bias initial value in meters
   inline void resetWithMeasurements(const Vector2 & measuredDcm,
                                     const Vector2 & measuredZMP,
-                                    const Matrix3 & rotation = Matrix3::Identity(),
+                                    const Matrix3 & rotation,
                                     bool measurementIsWithBias = true,
                                     const Vector2 & initBias = Vector2::Constant(0),
                                     const Vector2 & initBiasuncertainty = Vector2::Constant(defaultBiasUncertainty))

--- a/include/state-observation/dynamics-estimators/lipm-dcm-estimator.hpp
+++ b/include/state-observation/dynamics-estimators/lipm-dcm-estimator.hpp
@@ -30,8 +30,9 @@ namespace stateObservation
 /// The dynamics of the DCM depends on the Zero Moment Point.
 /// The DCM can be measured using the CoM and its velocity, but the CoM position can be biased.
 /// For instance if the measurement of the CoM is biased, or in presence of an external force
-/// the dynamics of the DCM is biased \f$\dot{\hat{\xi}} & =\omega_{0}(\hat{\xi}-z-b)\f$ where \f$\hat{\xi}$\f$ is the
-/// measured dcm and \f$b$\f$ is the bias. Also the measurement of the DCM can be noisy (since it uses CoM velocity
+/// the dynamics of the DCM is biased \f$\dot{\hat{\xi}} & =\omega_{0}(\hat{\xi}-\kappa z+\detla-b)\f$ where
+/// \f$\hat{\xi}$\f$ is the measured dcm, and \f$\gamma$\f$ and \f$\kappa$\f$ are known CoM offset and ZMP coefficient,
+/// and \f$b$\f$ is the unknown bias. Also the measurement of the DCM can be noisy (since it uses CoM velocity
 /// estimation).
 ///
 /// This estimator uses Kalman Filtering to estimate this bias and give a delay-free filtering of the DCM.
@@ -195,6 +196,34 @@ public:
     return omega0_;
   }
 
+  /// @brief Set an offset on the CoM dynamics
+  /// @details This is an offset that adds to the CoM and the bias in definin the DCM dynamics, it has the same effect
+  /// on the dynamics as manually modifying the estimated bias, but it does not need to interfer with the estimation,
+  /// especially when this offset is obtained from a different independent source (e.g. external force sensor).
+  ///
+  /// @param offset in meters
+  void setUnbiasedCoMOffset(const Vector2 & gamma);
+
+  /// @brief Get the ubiased offset on the CoM dynamics
+  /// @details gets the value set by setUnbiasedCoMOffset
+  ///
+  /// @return Vector2
+  Vector2 getUnbiasedCoMOffset() const
+  {
+    return gamma_;
+  }
+
+  /// @brief Set the ZMP oefficient
+  /// @param kappa is the zmp coefficient (no unit)
+  void setZMPCoef(double kappa);
+
+  /// @brief get the ZMP Coefficient
+  /// @return double
+  double getZMPCoef() const
+  {
+    return kappa_;
+  }
+
   ///@brief Set the Sampling Time
   ///
   ///@param dt sampling time
@@ -247,10 +276,15 @@ public:
   /// @param zmp         mesaurement of the ZMP in the world frame
   /// @param orientation the 3d orientation from which the yaw will be extracted. This orientation is from local to
   /// global. i.e. bias_global == orientation * bias*local
-  ///
-  inline void setInputs(const Vector2 & dcm, const Vector2 & zmp, const Matrix3 & orientation)
+  /// @param CoMOffset_gamma is the unbiased CoM offset in the dynamics of the DCM (see setUnbiasedCoMOffset)
+  /// @param ZMPCoef_kappa is the coefficient multiplied by the ZMP in the DCM dynamics (see setZMPCoef)
+  inline void setInputs(const Vector2 & dcm,
+                        const Vector2 & zmp,
+                        const Matrix3 & orientation,
+                        const Vector2 & CoMOffset_gamma = Vector2::Zero(),
+                        const double ZMPCoef_kappa = 1)
   {
-    setInputs(dcm, zmp, kine::rotationMatrixToYawAxisAgnostic(orientation));
+    setInputs(dcm, zmp, kine::rotationMatrixToYawAxisAgnostic(orientation), CoMOffset_gamma, ZMPCoef_kappa);
   }
 
   /// @brief Set the Inputs of the estimator.
@@ -259,9 +293,15 @@ public:
   /// @param zmp mesaurement of the ZMP in the world frame
   /// @param yaw is the yaw angle to be used. This orientation is from local to global. i.e. bias_global == R *
   /// bias*local
-  inline void setInputs(const Vector2 & dcm, const Vector2 & zmp, double yaw)
+  /// @param CoMOffset_gamma is the unbiased CoM offset in the dynamics of the DCM (see setUnbiasedCoMOffset)
+  /// @param ZMPCoef_kappa is the coefficient multiplied by the ZMP in the DCM dynamics (see setZMPCoef)
+  inline void setInputs(const Vector2 & dcm,
+                        const Vector2 & zmp,
+                        double yaw,
+                        const Vector2 & CoMOffset_gamma = Vector2::Zero(),
+                        const double ZMPCoef_kappa = 1)
   {
-    setInputs(dcm, zmp, Rotation2D(yaw).toRotationMatrix());
+    setInputs(dcm, zmp, Rotation2D(yaw).toRotationMatrix(), CoMOffset_gamma, ZMPCoef_kappa);
   }
 
   /// @brief Set the Inputs of the estimator.
@@ -269,7 +309,13 @@ public:
   /// @param dcm  measurement of the DCM in the world frame
   /// @param zmp  mesaurement of the ZMP in the world frame
   /// @param R    the 2x2 Matrix'representing the yaw angle i.e. bias_global == R * bias*local
-  void setInputs(const Vector2 & dcm, const Vector2 & zmp, const Matrix2 & R = Matrix2::Identity());
+  /// @param CoMOffset_gamma is the unbiased CoM offset in the dynamics of the DCM (see setUnbiasedCoMOffset)
+  /// @param ZMPCoef_kappa is the coefficient multiplied by the ZMP in the DCM dynamics (see setZMPCoef)
+  void setInputs(const Vector2 & dcm,
+                 const Vector2 & zmp,
+                 const Matrix2 & R = Matrix2::Identity(),
+                 const Vector2 & CoMOffset_gamma = Vector2::Zero(),
+                 const double ZMPCoef_kappa = 1);
 
   /// @brief Runs the estimation. Needs to be called every timestep
   ///
@@ -318,9 +364,13 @@ protected:
   void updateMatricesABQ_();
 
   double omega0_;
+  Vector2 gamma_ = Vector2::Zero();
+  double kappa_ = 1;
   double dt_;
   double biasDriftStd_;
   double zmpErrorStd_;
+
+  bool needUpdateMatrices_ = true;
 
   Vector2 previousZmp_;
 
@@ -328,12 +378,11 @@ protected:
 
   LinearKalmanFilter filter_;
   Matrix4 A_;
-  Matrix42 B_;
+  Matrix4 B_;
   /// this needs to be transposed
   Matrix24 C_;
   /// measurement noise
   Matrix2 R_;
-
   /// process noise
   Matrix4 Q_;
 


### PR DESCRIPTION
This allows to modify the modeled dynamics of the DCM, to take into account the case of an offset on the CoM contribution and a factor multiplying the ZMP. This is useful when we want to take into account the external forces similarly to Murooka et al. RAL 2021.