### PR TITLE
Accurate gravity acceleration

### DIFF
--- a/include/state-observation/tools/definitions.hpp
+++ b/include/state-observation/tools/definitions.hpp
@@ -616,7 +616,7 @@ typedef IndexedMatrixArrayT<Vector> IndexedVectorArray;
 
 namespace cst
 {
-constexpr double gravityConstant = 9.8;
+constexpr double gravityConstant = 9.80665;
 
 /// Gravity Vector along Z
 const Vector gravity = gravityConstant * Vector3::UnitZ();


### PR DESCRIPTION
This value is used in the [AttitudeObserver](https://github.com/jrl-umi3218/mc_state_observation/blob/main/include/mc_state_observation/AttitudeObserver.h) through the dynamics of IMU measurements
https://github.com/jrl-umi3218/state-observation/blob/43f370acae244bddf34e6e0ba5bd29bf60ef526c/src/linear-acceleration.cpp#L9
